### PR TITLE
"() is like void" instead of "() is like null"

### DIFF
--- a/02_Getting_Started.md
+++ b/02_Getting_Started.md
@@ -66,7 +66,7 @@ It is a function taking a string and returning `IO ()`
 (IO unit), that is an IO value expecting a callback of type
 `() -> IO something`.
 
-`()` is a bit like `null`, `nil`, or `None` in other languages.
+`()` is a bit like `void` in other languages.
 
 As you have seen how to attach callbacks you might ask by now
 how to actually do things.

--- a/02_Getting_Started.md
+++ b/02_Getting_Started.md
@@ -66,7 +66,7 @@ It is a function taking a string and returning `IO ()`
 (IO unit), that is an IO value expecting a callback of type
 `() -> IO something`.
 
-`()` is a bit like `void` in other languages.
+`()` is a bit like `void` or `None type` in other languages.
 
 As you have seen how to attach callbacks you might ask by now
 how to actually do things.


### PR DESCRIPTION
I believe that in most languages, `null`, and `None` are values while in this context `()` is a type. Unless im misstaken, roughly speaking, it indicates that what is 'returned' has no value which is similar to what `void` does in C-like languages and the `None type` is in python.

Im not sure wether or not nil is a type or a value as I havent worked much with languages that support it.